### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,6 @@
 name: run-tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/2rius/dart-transformer/security/code-scanning/1](https://github.com/2rius/dart-transformer/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
