### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   phpstan:
     name: phpstan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/2rius/dart-transformer/security/code-scanning/2](https://github.com/2rius/dart-transformer/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required. For this workflow, which only needs to read repository contents, set `permissions: contents: read` at the job level (under `phpstan:`) or at the workflow root. Since the error is flagged at the job level, and to minimize the scope of the change, add the following under the `phpstan:` job definition (after `name: phpstan` and before `runs-on: ubuntu-latest`). No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
