### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,9 @@ on:
       - 'composer.json'
       - 'composer.lock'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/2rius/dart-transformer/security/code-scanning/1](https://github.com/2rius/dart-transformer/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file. The best way is to add it at the root level (before `jobs:`), so it applies to all jobs unless overridden. For a test workflow that only checks out code and runs tests, the minimal required permission is `contents: read`. This change should be made at the top of the file, after the `name:` and before `concurrency:` or `jobs:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
